### PR TITLE
Fix make error

### DIFF
--- a/cnn/cnn/training.h
+++ b/cnn/cnn/training.h
@@ -2,6 +2,7 @@
 #define CNN_TRAINING_H_
 
 #include <vector>
+#include <iostream>
 #include "cnn/model.h"
 #include "cnn/shadow-params.h"
 


### PR DESCRIPTION
The make command generates the following error:
"In file included from ~/lstm-parser-dynamic/cnn/cnn/training.cc:1:0:
~/lstm-parser-dynamic/cnn/cnn/training.h: In member function ‘void cnn::Trainer::status()’:
~/lstm-parser-dynamic/cnn/cnn/training.h:40:5: error: ‘cerr’ is not a member of ‘std’"
To fix the previous error you can simply add 
"#include <iostream>"